### PR TITLE
Add interactive commands and modularize handlers

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,7 +2,7 @@ import asyncio
 
 from .config import dp
 from .storage import load_data, load_history
-from .handlers import number_request
+from .handlers import number_request, general
 
 load_data()
 load_history()

--- a/bot/handlers/general.py
+++ b/bot/handlers/general.py
@@ -1,0 +1,66 @@
+from aiogram import types
+
+from ..config import dp
+from ..queue import user_queue, user_queue_lock
+from ..storage import save_data
+from ..utils import fetch_russian_joke
+from .number_request import update_queue_messages
+
+
+@dp.message_handler(commands=["start"])
+async def cmd_start(msg: types.Message) -> None:
+    await msg.reply(
+        "Привет! Отправь <b>номер</b>, чтобы получить номер телефона.\n"
+        "Доступные команды: /help",
+        parse_mode="HTML",
+    )
+
+
+@dp.message_handler(commands=["help"])
+async def cmd_help(msg: types.Message) -> None:
+    await msg.reply(
+        "Доступные команды:\n"
+        "/start — приветствие\n"
+        "/help — список команд\n"
+        "/queue — ваша позиция в очереди\n"
+        "/leave — выйти из очереди\n"
+        "/joke — случайный анекдот",
+    )
+
+
+@dp.message_handler(commands=["queue"])
+async def cmd_queue(msg: types.Message) -> None:
+    async with user_queue_lock:
+        sorted_users = sorted(user_queue, key=lambda u: u["timestamp"])
+        for idx, user in enumerate(sorted_users):
+            if user["user_id"] == msg.from_user.id:
+                await msg.reply(
+                    f"⏳ Ваша позиция в очереди: <b>{idx + 1}</b>",
+                    parse_mode="HTML",
+                )
+                break
+        else:
+            await msg.reply("⚠️ Вас нет в очереди.")
+
+
+@dp.message_handler(commands=["leave"])
+async def cmd_leave(msg: types.Message) -> None:
+    removed = False
+    async with user_queue_lock:
+        for user in list(user_queue):
+            if user["user_id"] == msg.from_user.id:
+                user_queue.remove(user)
+                removed = True
+                break
+    if removed:
+        save_data()
+        await update_queue_messages()
+        await msg.reply("✅ Вы вышли из очереди.")
+    else:
+        await msg.reply("⚠️ Вас нет в очереди.")
+
+
+@dp.message_handler(commands=["joke"])
+async def cmd_joke(msg: types.Message) -> None:
+    joke = fetch_russian_joke()
+    await msg.reply(f"<code>{joke}</code>", parse_mode="HTML")


### PR DESCRIPTION
## Summary
- Add new handler module with commands like /start, /help, /queue, /leave, and /joke
- Register new handler module in bot initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6891a0ef2000832b8f7c749f8e63178b