### PR TITLE
Improve logging across bot

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -15,7 +15,10 @@ GROUP1_ID = int(getenv("GROUP1_ID", "0"))
 GROUP2_IDS = [int(x) for x in getenv("GROUP2_IDS", "").split(",") if x]
 TOPIC_IDS_GROUP1 = [int(x) for x in getenv("TOPIC_IDS_GROUP1", "").split(",") if x]
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 bot = Bot(token=API_TOKEN, parse_mode=types.ParseMode.HTML)

--- a/bot/handlers/general.py
+++ b/bot/handlers/general.py
@@ -1,6 +1,6 @@
 from aiogram import types
 
-from ..config import dp
+from ..config import dp, logger
 from ..queue import user_queue, user_queue_lock
 from ..storage import save_data
 from ..utils import fetch_russian_joke
@@ -9,6 +9,7 @@ from .number_request import update_queue_messages
 
 @dp.message_handler(commands=["start"])
 async def cmd_start(msg: types.Message) -> None:
+    logger.info(f"[CMD /start] user_id={msg.from_user.id}")
     await msg.reply(
         "Привет! Отправь <b>номер</b>, чтобы получить номер телефона.\n"
         "Доступные команды: /help",
@@ -18,6 +19,7 @@ async def cmd_start(msg: types.Message) -> None:
 
 @dp.message_handler(commands=["help"])
 async def cmd_help(msg: types.Message) -> None:
+    logger.info(f"[CMD /help] user_id={msg.from_user.id}")
     await msg.reply(
         "Доступные команды:\n"
         "/start — приветствие\n"
@@ -30,6 +32,7 @@ async def cmd_help(msg: types.Message) -> None:
 
 @dp.message_handler(commands=["queue"])
 async def cmd_queue(msg: types.Message) -> None:
+    logger.info(f"[CMD /queue] user_id={msg.from_user.id}")
     async with user_queue_lock:
         sorted_users = sorted(user_queue, key=lambda u: u["timestamp"])
         for idx, user in enumerate(sorted_users):
@@ -45,6 +48,7 @@ async def cmd_queue(msg: types.Message) -> None:
 
 @dp.message_handler(commands=["leave"])
 async def cmd_leave(msg: types.Message) -> None:
+    logger.info(f"[CMD /leave] user_id={msg.from_user.id}")
     removed = False
     async with user_queue_lock:
         for user in list(user_queue):
@@ -62,5 +66,6 @@ async def cmd_leave(msg: types.Message) -> None:
 
 @dp.message_handler(commands=["joke"])
 async def cmd_joke(msg: types.Message) -> None:
+    logger.info(f"[CMD /joke] user_id={msg.from_user.id}")
     joke = fetch_russian_joke()
     await msg.reply(f"<code>{joke}</code>", parse_mode="HTML")

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -3,6 +3,7 @@ import os
 from collections import deque
 
 from .queue import number_queue, user_queue, bindings, IGNORED_TOPICS
+from .config import logger
 
 QUEUE_FILE = 'number_queue.json'
 USER_FILE = 'user_queue.json'
@@ -22,6 +23,13 @@ def save_data():
         json.dump(bindings, f)
     with open(IGNORED_FILE, 'w') as f:
         json.dump(list(IGNORED_TOPICS), f)
+    logger.info(
+        "[SAVE] numbers=%d users=%d bindings=%d ignored=%d",
+        len(number_queue),
+        len(user_queue),
+        len(bindings),
+        len(IGNORED_TOPICS),
+    )
 
 
 def load_data():
@@ -37,6 +45,13 @@ def load_data():
     if os.path.exists(IGNORED_FILE):
         with open(IGNORED_FILE, 'r') as f:
             IGNORED_TOPICS.update(json.load(f))
+    logger.info(
+        "[LOAD] numbers=%d users=%d bindings=%d ignored=%d",
+        len(number_queue),
+        len(user_queue),
+        len(bindings),
+        len(IGNORED_TOPICS),
+    )
 
 
 def load_history():
@@ -44,8 +59,10 @@ def load_history():
     if os.path.exists(HISTORY_FILE):
         with open(HISTORY_FILE, 'r') as f:
             history = json.load(f)
+    logger.info("[LOAD HISTORY] entries=%d", len(history))
 
 
 def save_history():
     with open(HISTORY_FILE, 'w') as f:
         json.dump(history, f)
+    logger.info("[SAVE HISTORY] entries=%d", len(history))

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
-from bot.config import dp
+from bot.config import dp, logger
 from aiogram import executor
 
 if __name__ == "__main__":
+    logger.info("Starting bot polling")
     executor.start_polling(dp, skip_updates=True)


### PR DESCRIPTION
## Summary
- enhance logging format and coverage across the bot

## Testing
- `pytest`
- `python -m py_compile main.py bot/config.py bot/storage.py bot/handlers/general.py bot/handlers/number_request.py`


------
https://chatgpt.com/codex/tasks/task_e_6891aa80e08c832ba89e44ce08c099df