### PR TITLE
Fix surrogate emoji encoding in keyboard

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -10,7 +10,7 @@ def get_number_action_keyboard():
     return (
         InlineKeyboardMarkup(row_width=2)
         .add(
-            InlineKeyboardButton("\uD83D\uDD04 \u0414\u0440\u0443\u0433\u043E\u0439", callback_data="skip_number"),
+            InlineKeyboardButton("\U0001F504 \u0414\u0440\u0443\u0433\u043E\u0439", callback_data="skip_number"),
             InlineKeyboardButton("\u26D4 \u041F\u0440\u043E\u0431\u043B\u0435\u043C\u0430", callback_data="error_reason"),
         )
     )


### PR DESCRIPTION
## Summary
- use proper emoji code points in number action keyboard to avoid surrogate pairs causing send failures

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891af5775f4832b9d061c6be34ddb21