### PR TITLE
Track issued numbers and add statistics commands

### DIFF
--- a/bot/handlers/number_request.py
+++ b/bot/handlers/number_request.py
@@ -17,7 +17,15 @@ from ..queue import (
     number_queue_lock,
     user_queue_lock,
 )
-from ..storage import save_data, load_data, load_history, save_history, history, QUEUE_FILE
+from ..storage import (
+    save_data,
+    load_data,
+    load_history,
+    save_history,
+    history,
+    issued_numbers,
+    QUEUE_FILE,
+)
 from ..utils import phone_pattern, get_number_action_keyboard, fetch_russian_joke
 
 
@@ -81,7 +89,7 @@ async def handle_number_request(msg: types.Message):
             "text": number['text'],
             "added_at": number.get("added_at"),
         }
-
+        issued_numbers.append(number["text"])
         save_data()
         logger.info(f"[ВЫДАН НОМЕР] {number['text']} → user_id={msg.from_user.id}")
     else:
@@ -631,7 +639,7 @@ async def try_dispatch_next():
             "added_at": number.get("added_at"),
             "queue_data": user.copy(),
         }
-
+        issued_numbers.append(number["text"])
         save_data()
         logger.info(
             f"[АВТОВЫДАЧА] {number['text']} → user_id={user['user_id']}"

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -10,8 +10,10 @@ USER_FILE = 'user_queue.json'
 BINDINGS_FILE = 'bindings.json'
 HISTORY_FILE = 'history.json'
 IGNORED_FILE = 'ignored_topics.json'
+ISSUED_FILE = 'issued_numbers.json'
 
 history = []
+issued_numbers = []
 
 
 def save_data():
@@ -23,12 +25,15 @@ def save_data():
         json.dump(bindings, f)
     with open(IGNORED_FILE, 'w') as f:
         json.dump(list(IGNORED_TOPICS), f)
+    with open(ISSUED_FILE, 'w') as f:
+        json.dump(issued_numbers, f)
     logger.info(
-        "[SAVE] numbers=%d users=%d bindings=%d ignored=%d",
+        "[SAVE] numbers=%d users=%d bindings=%d ignored=%d issued=%d",
         len(number_queue),
         len(user_queue),
         len(bindings),
         len(IGNORED_TOPICS),
+        len(issued_numbers),
     )
 
 
@@ -45,12 +50,16 @@ def load_data():
     if os.path.exists(IGNORED_FILE):
         with open(IGNORED_FILE, 'r') as f:
             IGNORED_TOPICS.update(json.load(f))
+    if os.path.exists(ISSUED_FILE):
+        with open(ISSUED_FILE, 'r') as f:
+            issued_numbers.extend(json.load(f))
     logger.info(
-        "[LOAD] numbers=%d users=%d bindings=%d ignored=%d",
+        "[LOAD] numbers=%d users=%d bindings=%d ignored=%d issued=%d",
         len(number_queue),
         len(user_queue),
         len(bindings),
         len(IGNORED_TOPICS),
+        len(issued_numbers),
     )
 
 


### PR DESCRIPTION
## Summary
- Persist every issued phone number in `issued_numbers.json`
- Add `/статистика` command to show total numbers issued
- Add `/выгруз` command to export all issued numbers as a file

## Testing
- `python -m py_compile bot/storage.py bot/handlers/general.py bot/handlers/number_request.py`

------
https://chatgpt.com/codex/tasks/task_e_6891bd05dc54832b8e3f03d1d999a14f