### PR TITLE
feat: diversify joke selection

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,6 +1,7 @@
-import re
-from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 import random
+import re
+from typing import List
+from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 
 phone_pattern = re.compile(r"(?:\+7|7|8)?[\s\-]?\(?\d{3}\)?[\s\-]?\d{3}[\s\-]?\d{2}[\s\-]?\d{2}|\b\d{10}\b")
 
@@ -15,12 +16,25 @@ def get_number_action_keyboard():
         )
     )
 
-JOKES = [
+JOKES: List[str] = [
     "— Мама, что такое черный юмор? — Сынок, видишь вон там мужчину без рук? Вели ему похлопать в ладоши. — Я же слепой! — Вот именно.",
     "Я копал яму в саду и вдруг откопал целый сундук с золотом. Потом вспомнил, зачем я копал яму.",
     "— Будешь выходить — труп вынеси! — Может мусор? — Может мусор, может сантехник, бог его знает…",
+    "— Пап, а кто такой оптимист? — Это человек, который нашёл иголку в стоге сена и радуется, что не укололся.",
+    "Звонок в дверь. Мужик открывает — перед ним курица с топором. \"Петух дома?\"",
+    "— Доктор, все меня игнорируют! — Следующий!",
+    "Встречаются два программиста: — Ты женат? — Нет. — И я тоже ноль.",
+    "В ресторане: — Официант, у меня суп недосоленный. — Сейчас добавим поллитра!",
+    "Говорят, что когда человек умирает, перед его глазами проходит вся жизнь. Поэтому у вас при смерти может зависнуть браузер.",
+    "— Ты что, кушаешь в классе? — Это не я, это мой пищеварительный процесс.",
 ]
 
+_available_jokes: List[str] = []
 
-def fetch_russian_joke():
-    return random.choice(JOKES)
+
+def fetch_russian_joke() -> str:
+    """Return a random joke without immediate repetition."""
+    global _available_jokes
+    if not _available_jokes:
+        _available_jokes = random.sample(JOKES, len(JOKES))
+    return _available_jokes.pop()


### PR DESCRIPTION
## Summary
- expand Russian joke list and add unique selection without repeats

## Testing
- `python -m py_compile bot/utils.py`
- `python - <<'PY'
import types, sys, importlib.util
aiogram = types.ModuleType('aiogram')
aiogram_types = types.ModuleType('aiogram.types')
class InlineKeyboardMarkup:
    def __init__(self, row_width):
        self.row_width = row_width
    def add(self, *args, **kwargs):
        return self
class InlineKeyboardButton:
    def __init__(self, *args, **kwargs):
        pass
aiogram.types = aiogram_types
aiogram_types.InlineKeyboardMarkup = InlineKeyboardMarkup
aiogram_types.InlineKeyboardButton = InlineKeyboardButton
sys.modules['aiogram'] = aiogram
sys.modules['aiogram.types'] = aiogram_types

spec = importlib.util.spec_from_file_location('utils', 'bot/utils.py')
utils = importlib.util.module_from_spec(spec)
spec.loader.exec_module(utils)
for _ in range(5):
    print(utils.fetch_russian_joke())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891c423669c832bb247048633b54446