### PR TITLE
Fix imports for number_request handlers

### DIFF
--- a/bot/handlers/number_request/callbacks.py
+++ b/bot/handlers/number_request/callbacks.py
@@ -2,8 +2,8 @@ from datetime import datetime, timedelta
 
 from aiogram import types
 
-from ..config import dp, bot, GROUP2_IDS, logger
-from ..queue import (
+from ...config import dp, bot, GROUP2_IDS, logger
+from ...queue import (
     number_queue,
     user_queue,
     bindings,
@@ -11,7 +11,7 @@ from ..queue import (
     number_queue_lock,
     user_queue_lock,
 )
-from ..storage import save_data
+from ...storage import save_data
 from .utils import update_queue_messages, try_dispatch_next
 
 

--- a/bot/handlers/number_request/commands.py
+++ b/bot/handlers/number_request/commands.py
@@ -4,8 +4,8 @@ from html import escape
 
 from aiogram import types
 
-from ..config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
-from ..queue import (
+from ...config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
+from ...queue import (
     number_queue,
     user_queue,
     bindings,
@@ -13,8 +13,8 @@ from ..queue import (
     number_queue_lock,
     user_queue_lock,
 )
-from ..storage import save_data, QUEUE_FILE
-from ..utils import phone_pattern
+from ...storage import save_data, QUEUE_FILE
+from ...utils import phone_pattern
 
 
 @dp.message_handler(commands=["work"])

--- a/bot/handlers/number_request/request.py
+++ b/bot/handlers/number_request/request.py
@@ -5,8 +5,8 @@ from html import escape
 
 from aiogram import types
 
-from ..config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
-from ..queue import (
+from ...config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
+from ...queue import (
     number_queue,
     user_queue,
     bindings,
@@ -15,8 +15,8 @@ from ..queue import (
     number_queue_lock,
     user_queue_lock,
 )
-from ..storage import save_data, history, issued_numbers
-from ..utils import phone_pattern, get_number_action_keyboard
+from ...storage import save_data, history, issued_numbers
+from ...utils import phone_pattern, get_number_action_keyboard
 from .utils import update_queue_messages, try_dispatch_next
 
 

--- a/bot/handlers/number_request/utils.py
+++ b/bot/handlers/number_request/utils.py
@@ -5,8 +5,8 @@ from html import escape
 from aiogram import types
 from aiogram.utils.exceptions import MessageNotModified
 
-from ..config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
-from ..queue import (
+from ...config import dp, bot, GROUP1_ID, GROUP2_IDS, TOPIC_IDS_GROUP1, logger
+from ...queue import (
     number_queue,
     user_queue,
     bindings,
@@ -15,8 +15,8 @@ from ..queue import (
     number_queue_lock,
     user_queue_lock,
 )
-from ..storage import save_data, save_history, history, issued_numbers
-from ..utils import get_number_action_keyboard, fetch_russian_joke
+from ...storage import save_data, save_history, history, issued_numbers
+from ...utils import get_number_action_keyboard, fetch_russian_joke
 
 
 async def update_queue_messages():


### PR DESCRIPTION
## Summary
- repair module imports in number_request handlers to reference bot package root
- keep queue messaging utilities accessible across handlers

## Testing
- `python -m py_compile main.py bot/handlers/number_request/*.py bot/handlers/general.py bot/storage.py bot/utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6891cb8d1090832bb6b6fea4e5a68b2c