### PR TITLE
Add work scheduling commands

### DIFF
--- a/bot/handlers/number_request/__init__.py
+++ b/bot/handlers/number_request/__init__.py
@@ -12,6 +12,8 @@ from .commands import (
     handle_queue_status,
     handle_id_command,
     add_topic_to_ignore,
+    handle_stop_work,
+    handle_start_work,
 )
 from .utils import (
     update_queue_messages,
@@ -33,6 +35,8 @@ __all__ = [
     "handle_queue_status",
     "handle_id_command",
     "add_topic_to_ignore",
+    "handle_stop_work",
+    "handle_start_work",
     "update_queue_messages",
     "handle_photo_response",
     "joke_dispatcher",

--- a/bot/handlers/number_request/request.py
+++ b/bot/handlers/number_request/request.py
@@ -15,6 +15,7 @@ from ...queue import (
     number_queue_lock,
     user_queue_lock,
 )
+from ... import queue as queue_state
 from ...storage import save_data, history, issued_numbers
 from ...utils import phone_pattern, get_number_action_keyboard
 from .utils import update_queue_messages, try_dispatch_next
@@ -25,6 +26,8 @@ async def handle_number_request(msg: types.Message):
     logger.info(
         f"[ЗАПРОС НОМЕРА] user_id={msg.from_user.id} chat_id={msg.chat.id} topic={msg.message_thread_id}"
     )
+    if not queue_state.WORKING:
+        return await msg.reply("⏸️ Бот сейчас не выдаёт номера.")
     if msg.chat.type == "private":
         logger.debug(f"[ЗАПРОС НОМЕРА] user_id={msg.from_user.id} в приватном чате")
         return await msg.reply(
@@ -117,6 +120,8 @@ async def handle_number_request(msg: types.Message):
 
 @dp.message_handler(content_types=types.ContentTypes.TEXT)
 async def handle_number_sources(msg: types.Message):
+    if not queue_state.WORKING:
+        return
     if msg.message_thread_id in IGNORED_TOPICS:
         return
     if msg.chat.type == "private":

--- a/bot/handlers/number_request/utils.py
+++ b/bot/handlers/number_request/utils.py
@@ -15,6 +15,7 @@ from ...queue import (
     number_queue_lock,
     user_queue_lock,
 )
+from ... import queue as queue_state
 from ...storage import save_data, save_history, history, issued_numbers
 from ...utils import get_number_action_keyboard, fetch_russian_joke
 
@@ -114,6 +115,8 @@ async def joke_dispatcher():
 
 
 async def try_dispatch_next():
+    if not queue_state.WORKING:
+        return
     async with number_queue_lock:
         empty_numbers = not number_queue
     async with user_queue_lock:

--- a/bot/queue.py
+++ b/bot/queue.py
@@ -10,3 +10,7 @@ IGNORED_TOPICS = set()
 # Locks for async-safe operations on queues
 number_queue_lock = asyncio.Lock()
 user_queue_lock = asyncio.Lock()
+
+# Global work state
+WORKING = True
+start_task = None


### PR DESCRIPTION
## Summary
- Add global work state with `/stop_work` to pause bot and `/start_work` to resume, optionally at a scheduled time in Moscow timezone
- Ensure number request and source handlers respect the paused state
- Prevent automatic dispatch of numbers while paused

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6891d01d5680832badc14626e6f98254