### PR TITLE
Support stats command and improve start/stop handlers

### DIFF
--- a/bot/handlers/general.py
+++ b/bot/handlers/general.py
@@ -74,9 +74,12 @@ async def cmd_joke(msg: types.Message) -> None:
     await msg.reply(f"<code>{escape(joke)}</code>", parse_mode="HTML")
 
 
-@dp.message_handler(commands=["статистика"])
+@dp.message_handler(commands=["stats"])
+@dp.message_handler(
+    lambda m: m.text and m.text.lower().startswith("/статистика")
+)
 async def cmd_stats(msg: types.Message) -> None:
-    logger.info(f"[CMD /статистика] user_id={msg.from_user.id}")
+    logger.info(f"[CMD {msg.text}] user_id={msg.from_user.id}")
     await msg.reply(
         f"\U0001F4CA Всего выдано номеров: <b>{len(issued_numbers)}</b>",
         parse_mode="HTML",

--- a/bot/handlers/number_request/commands.py
+++ b/bot/handlers/number_request/commands.py
@@ -299,9 +299,9 @@ async def handle_thread_remove(msg: types.Message):
         await msg.reply("Такой темы нет в списке")
 
 
-@dp.message_handler(commands=["stop_work"])
+@dp.message_handler(commands=["stop_work", "stopwork", "stop"])
 async def handle_stop_work(msg: types.Message):
-    if msg.chat.id not in GROUP2_IDS:
+    if msg.chat.id not in GROUP2_IDS and msg.from_user.id != ADMIN_ID:
         return
     if queue_state.start_task:
         queue_state.start_task.cancel()
@@ -310,9 +310,9 @@ async def handle_stop_work(msg: types.Message):
     await msg.reply("⏸️ Бот приостановил работу.")
 
 
-@dp.message_handler(commands=["start_work"])
+@dp.message_handler(commands=["start_work", "startwork"])
 async def handle_start_work(msg: types.Message):
-    if msg.chat.id not in GROUP2_IDS:
+    if msg.chat.id not in GROUP2_IDS and msg.from_user.id != ADMIN_ID:
         return
 
     args = msg.get_args().strip()


### PR DESCRIPTION
## Summary
- handle `/статистика` even without Telegram command entity and add `/stats` alias
- allow admins to run `/start_work` and `/stop_work` anywhere and add alternative command names

## Testing
- `python -m py_compile bot/handlers/general.py bot/handlers/number_request/commands.py`


------
https://chatgpt.com/codex/tasks/task_e_6891d99f2090832b91f7afdaa8751771