### PR TITLE
Improve work command scheduling and stats command

### DIFF
--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -2,7 +2,8 @@ import asyncio
 
 from .config import dp
 from .storage import load_data, load_history
-from .handlers import number_request, general
+# Import general handlers before number_request so command handlers register first
+from .handlers import general, number_request
 
 load_data()
 load_history()

--- a/bot/handlers/general.py
+++ b/bot/handlers/general.py
@@ -27,15 +27,15 @@ async def cmd_help(msg: types.Message) -> None:
         "Доступные команды:\n"
         "/start — приветствие\n"
         "/help — список команд\n"
-        "/queue — ваша позиция в очереди\n"
+        "/queue (/очередь) — ваша позиция в очереди\n"
         "/leave — выйти из очереди\n"
-        "/joke — случайный анекдот",
+        "/joke (/анекдот) — случайный анекдот",
     )
 
 
-@dp.message_handler(commands=["queue"])
+@dp.message_handler(commands=["queue", "очередь"])
 async def cmd_queue(msg: types.Message) -> None:
-    logger.info(f"[CMD /queue] user_id={msg.from_user.id}")
+    logger.info(f"[CMD {msg.text}] user_id={msg.from_user.id}")
     async with user_queue_lock:
         sorted_users = sorted(user_queue, key=lambda u: u["timestamp"])
         for idx, user in enumerate(sorted_users):
@@ -67,16 +67,18 @@ async def cmd_leave(msg: types.Message) -> None:
         await msg.reply("⚠️ Вас нет в очереди.")
 
 
-@dp.message_handler(commands=["joke"])
+@dp.message_handler(commands=["joke", "анекдот"])
 async def cmd_joke(msg: types.Message) -> None:
-    logger.info(f"[CMD /joke] user_id={msg.from_user.id}")
+    logger.info(f"[CMD {msg.text}] user_id={msg.from_user.id}")
     joke = fetch_russian_joke()
     await msg.reply(f"<code>{escape(joke)}</code>", parse_mode="HTML")
 
 
+# Support multiple language variations for the stats command
 @dp.message_handler(commands=["stats"])
 @dp.message_handler(
-    lambda m: m.text and m.text.lower().startswith("/статистика")
+    lambda m: m.text
+    and m.text.lower().startswith( ("/стат", "/stat") )
 )
 async def cmd_stats(msg: types.Message) -> None:
     logger.info(f"[CMD {msg.text}] user_id={msg.from_user.id}")

--- a/bot/handlers/number_request/__init__.py
+++ b/bot/handlers/number_request/__init__.py
@@ -1,4 +1,3 @@
-from .request import handle_number_request, handle_number_sources
 from .callbacks import (
     error_reason_menu,
     handle_skip_number,
@@ -21,6 +20,7 @@ from .utils import (
     joke_dispatcher,
     try_dispatch_next,
 )
+from .request import handle_number_request, handle_number_sources
 
 __all__ = [
     "handle_number_request",

--- a/bot/handlers/number_request/commands.py
+++ b/bot/handlers/number_request/commands.py
@@ -27,6 +27,7 @@ from ...queue import (
 from ... import queue as queue_state
 from ...storage import save_data, QUEUE_FILE
 from ...utils import phone_pattern
+from .utils import try_dispatch_next
 from ... import config as cfg
 
 
@@ -341,6 +342,7 @@ async def handle_start_work(msg: types.Message):
                 await bot.send_message(msg.chat.id, "▶️ Бот возобновил работу.")
             except Exception as e:
                 logger.warning(f"[START_WORK_NOTIFY] {e}")
+            await try_dispatch_next()
 
         queue_state.start_task = asyncio.create_task(resume())
         await msg.reply(
@@ -352,4 +354,5 @@ async def handle_start_work(msg: types.Message):
             queue_state.start_task = None
         queue_state.WORKING = True
         await msg.reply("▶️ Бот возобновил работу.")
+        await try_dispatch_next()
 

--- a/bot/handlers/number_request/request.py
+++ b/bot/handlers/number_request/request.py
@@ -119,7 +119,10 @@ async def handle_number_request(msg: types.Message):
         await update_queue_messages()
 
 
-@dp.message_handler(content_types=types.ContentTypes.TEXT)
+@dp.message_handler(
+    lambda m: not (m.text and m.text.startswith("/")),
+    content_types=types.ContentTypes.TEXT,
+)
 async def handle_number_sources(msg: types.Message):
     if not queue_state.WORKING:
         return

--- a/bot/handlers/number_request/utils.py
+++ b/bot/handlers/number_request/utils.py
@@ -138,7 +138,7 @@ async def try_dispatch_next():
                     logger.warning(f"[ОШИБКА ОПОВЕЩЕНИЯ] тема {topic_id}: {e}")
         return
 
-    while True:
+    while queue_state.WORKING:
         async with number_queue_lock:
             async with user_queue_lock:
                 if number_queue and user_queue:
@@ -151,6 +151,13 @@ async def try_dispatch_next():
                     user_queue.remove(user)
                 else:
                     break
+
+        if not queue_state.WORKING:
+            async with number_queue_lock:
+                number_queue.appendleft(number)
+            async with user_queue_lock:
+                user_queue.appendleft(user)
+            break
 
         asyncio.create_task(update_queue_messages())
 


### PR DESCRIPTION
## Summary
- ensure try_dispatch_next runs after /start_work and after scheduled resumes
- stop dispatch loop when work paused
- accept more command variations for /stats
- register command handlers before catch-all text handler so commands respond
- allow /queue and /joke Russian aliases and block catch-all from absorbing commands

## Testing
- `python -m py_compile bot/__init__.py bot/handlers/number_request/__init__.py bot/handlers/general.py bot/handlers/number_request/commands.py bot/handlers/number_request/utils.py bot/handlers/number_request/request.py`


------
https://chatgpt.com/codex/tasks/task_e_6891db7832b4832bb4b8f36e408e6693