### PR TITLE
Keep contact button active after code submission

### DIFF
--- a/bot/handlers/number_request/callbacks.py
+++ b/bot/handlers/number_request/callbacks.py
@@ -7,6 +7,7 @@ from ...queue import (
     number_queue,
     user_queue,
     bindings,
+    contact_bindings,
     blocked_numbers,
     contact_requests,
     number_queue_lock,
@@ -66,7 +67,8 @@ async def handle_skip_number(call: types.CallbackQuery):
 @dp.callback_query_handler(lambda c: c.data == "contact_drop")
 async def handle_contact_drop(call: types.CallbackQuery):
     msg_id = call.message.message_id
-    binding = bindings.get(str(msg_id))
+    msg_key = str(msg_id)
+    binding = bindings.get(msg_key) or contact_bindings.get(msg_key)
 
     if not binding:
         return await call.answer("⚠️ Номер не найден или уже обработан.", show_alert=True)

--- a/bot/queue.py
+++ b/bot/queue.py
@@ -4,6 +4,7 @@ import asyncio
 number_queue = deque()
 user_queue = deque()
 bindings = {}
+contact_bindings = {}
 blocked_numbers = {}
 IGNORED_TOPICS = set()
 contact_requests = {}


### PR DESCRIPTION
## Summary
- retain drop contact info after code submission
- allow 'Связь с дропом' button to work even after code forwarded

## Testing
- `python -m py_compile bot/queue.py bot/handlers/number_request/utils.py bot/handlers/number_request/callbacks.py`


------
https://chatgpt.com/codex/tasks/task_e_6891e7dbaabc832b8a3ba5a83ca2fabb