### PR TITLE
Route contact messages to source group

### DIFF
--- a/bot/handlers/number_request/utils.py
+++ b/bot/handlers/number_request/utils.py
@@ -109,8 +109,15 @@ async def handle_photo_response(msg: types.Message):
     finally:
         bindings.pop(msg_key, None)
         active_numbers.discard(number)
+        contact_info = {
+            "text": number,
+            "group_id": binding["group_id"],
+            "topic_id": binding["topic_id"],
+            "orig_msg_id": binding["orig_msg_id"],
+        }
         if drop_id:
-            contact_bindings[msg_key] = {"drop_id": drop_id, "text": number}
+            contact_info["drop_id"] = drop_id
+        contact_bindings[msg_key] = contact_info
         save_data()
 
 


### PR DESCRIPTION
## Summary
- Forward contact_drop messages back to the group and thread where the number originated
- Preserve group/thread metadata after codes are sent

## Testing
- `python -m py_compile bot/handlers/number_request/utils.py bot/handlers/number_request/callbacks.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892f816117c832bba11709f219b8317